### PR TITLE
Disabled dark mode behaviour

### DIFF
--- a/main_bundle.spec
+++ b/main_bundle.spec
@@ -69,6 +69,7 @@ app = BUNDLE(coll,
              icon="./tmp_dependencies/images/raidionics-logo.icns",
              bundle_identifier=None,
              info_plist={
+                'NSRequiresAquaSystemAppearance': 'true',
                 'CFBundleDisplayName': 'Raidionics',
                 'CFBundleExecutable': 'Raidionics',
                 'CFBundleIdentifier': 'Raidionics',


### PR DESCRIPTION
Basically set `NSRequiresAquaSystemAppearance` to `true` in the Info.plist for the installer.