### PR TITLE
macOS fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,8 +60,8 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    if platform.system() == 'Windows':
-        import multiprocessing as mp
-        mp.freeze_support()
-        mp.set_start_method('spawn', force=True)
+    # if platform.system() == 'Windows':
+    import multiprocessing as mp
+    mp.freeze_support()
+    mp.set_start_method('spawn', force=True)
     main(sys.argv[1:])

--- a/main.py
+++ b/main.py
@@ -61,6 +61,7 @@ def main(argv):
 
 if __name__ == "__main__":
     if platform.system() == 'Windows':
-        from multiprocessing import freeze_support
-        freeze_support()
+        import multiprocessing as mp
+        mp.freeze_support()
+        mp.set_start_method('spawn', force=True)
     main(sys.argv[1:])

--- a/utils/backend_logic.py
+++ b/utils/backend_logic.py
@@ -115,8 +115,7 @@ def run_segmentation(model_name: str, patient_parameters: PatientParameters, que
         # Execution call
         # from raidionicsseg.fit import run_model
         # run_model(seg_config_filename)
-
-        mp.set_start_method('spawn', force=True)
+        # mp.set_start_method('spawn', force=True)
         with mp.Pool(processes=1, maxtasksperchild=1) as p:  # , initializer=initializer)
             result = p.map_async(run_model_wrapper, ((seg_config_filename, SoftwareConfigResources.getInstance().get_session_log_filename()),))
             ret = result.get()[0]
@@ -268,7 +267,7 @@ def run_reporting(model_name, patient_parameters, queue):
         # from raidionicsrads.compute import run_rads
         # run_rads(rads_config_filename)
 
-        mp.set_start_method('spawn', force=True)
+        #mp.set_start_method('spawn', force=True)
         with mp.Pool(processes=1, maxtasksperchild=1) as p:  # , initializer=initializer)
             result = p.map_async(run_rads_wrapper, ((rads_config_filename, SoftwareConfigResources.getInstance().get_session_log_filename()),))
             ret = result.get()[0]


### PR DESCRIPTION
We actually need to use `freeze_support` for **both** Windows and macOS. This was surpring. I found that from checking some threads on stack overflow.

`freeze_support` should in theory do nothing on Ubuntu, but I would just have it there for all operating systems, if it works.

Also, it was recommended to move the `spawn_method` stuff to the `if __name__ == "__main__"` right after the `freeze_support`.

Just tested the binary installers on both Windows and macOS and seems to work!

We can refactor the code at a later stage. Now we are ready for the final tests on Ubuntu and then publish the release!