### PR TITLE
Remove .raidionics/ directory during install and uninstall for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 ![CI](https://github.com/dbouget/Raidionics/workflows/Build%20macOS/badge.svg?branch=master&event=push)
 
 Software to automatically segment brain tumors from pre- and post-operative MRI scans, compute their characteristics (e.g., volume, location), and generate a standardized report.
-The software was first introduced in the article "Brain tumor preoperative surgery imaging: models and software solutions for
-segmentation and standardized reporting", which has been published in [Frontiers in Neurology](https://www.frontiersin.org/articles/10.3389/fneur.2022.932219/full).  
+The software was first introduced in the article _"Brain tumor preoperative surgery imaging: models and software solutions for
+segmentation and standardized reporting"_, which has been published in [Frontiers in Neurology](https://www.frontiersin.org/articles/10.3389/fneur.2022.932219/full).  
 
 <p align="center">
 <img src="assets/images/Preview_SingleUse.gif" width="85%">
@@ -23,9 +23,10 @@ The current version (i.e., v1.2) provides a more user-friendly graphical user in
 
 
 ## Installation
-An installer is provided for the three main Operating Systems: Windows (v10, 64-bit), Ubuntu Linux (>= 18.04), macOS (>= 10.15 Catalina) and macOS ARM (M1 chip). 
+An installer is provided for the three main Operating Systems: Windows (v10, 64-bit), Ubuntu Linux (>= 18.04), macOS (>= 10.15 Catalina), and macOS ARM (M1 chip). 
 The software can be downloaded from [here](https://github.com/dbouget/Raidionics/releases) (see **Assets**).  
-N-B: For re-installation, it is recommended to manually delete the .raidionics folder located inside your home directory.
+
+**NOTE:** For reinstallation, it is recommended to _manually delete_ the `.raidionics/` folder located inside your home directory.
 
 These steps are only needed to do once:
 1) Download the installer to your Operating System.
@@ -36,12 +37,13 @@ These steps are only needed to do once:
 If you are using Raidionics in your research, please use the following citation:
 ```
 @article{10.3389/fneur.2022.932219,
-title={Preoperative Brain Tumor Imaging: Models and Software for Segmentation and Standardized Reporting},
-author={Bouget, David and Pedersen, André and Jakola, Asgeir S. and Kavouridis, Vasileios and Emblem, Kyrre E. and Eijgelaar, Roelant S. and Kommers, Ivar and Ardon, Hilko and Barkhof, Frederik and Bello, Lorenzo and Berger, Mitchel S. and Conti Nibali, Marco and Furtner, Julia and Hervey-Jumper, Shawn and Idema, Albert J. S. and Kiesel, Barbara and Kloet, Alfred and Mandonnet, Emmanuel and Müller, Domenique M. J. and Robe, Pierre A. and Rossi, Marco and Sciortino, Tommaso and Van den Brink, Wimar A. and Wagemakers, Michiel and Widhalm, Georg and Witte, Marnix G. and Zwinderman, Aeilko H. and De Witt Hamer, Philip C. and Solheim, Ole and Reinertsen, Ingerid},
-journal={Frontiers in Neurology},
-volume={13},
-year={2022},
-url={https://www.frontiersin.org/articles/10.3389/fneur.2022.932219},
-doi={10.3389/fneur.2022.932219},
-issn={1664-2295}}
+    title={Preoperative Brain Tumor Imaging: Models and Software for Segmentation and Standardized Reporting},
+    author={Bouget, David and Pedersen, André and Jakola, Asgeir S. and Kavouridis, Vasileios and Emblem, Kyrre E. and Eijgelaar, Roelant S. and Kommers, Ivar and Ardon, Hilko and Barkhof, Frederik and Bello, Lorenzo and Berger, Mitchel S. and Conti Nibali, Marco and Furtner, Julia and Hervey-Jumper, Shawn and Idema, Albert J. S. and Kiesel, Barbara and Kloet, Alfred and Mandonnet, Emmanuel and Müller, Domenique M. J. and Robe, Pierre A. and Rossi, Marco and Sciortino, Tommaso and Van den Brink, Wimar A. and Wagemakers, Michiel and Widhalm, Georg and Witte, Marnix G. and Zwinderman, Aeilko H. and De Witt Hamer, Philip C. and Solheim, Ole and Reinertsen, Ingerid},
+    journal={Frontiers in Neurology},
+    volume={13},
+    year={2022},
+    url={https://www.frontiersin.org/articles/10.3389/fneur.2022.932219},
+    doi={10.3389/fneur.2022.932219},
+    issn={1664-2295}
+}
 ```

--- a/assets/Raidionics.nsi
+++ b/assets/Raidionics.nsi
@@ -109,7 +109,7 @@ WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayVersion" "${VERSION}"
 WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "Publisher" "${COMP_NAME}"
 
 # Delete .raidionics/ directory if it exists
-RmDir /r "$PROFILE/.raidionics/"
+RMDir /r "$PROFILE\.raidionics\"
 
 # Create directory
 CreateDirectory $INSTDIR
@@ -136,8 +136,8 @@ SectionEnd
 # Remove location where program is installed as well as addition .raidionics/ directory in home directory
 Section Uninstall
 ${INSTALL_TYPE}
-RmDir /r "$INSTDIR"
-RmDir /r "$PROFILE/.raidionics/"
+RMDir /r "$INSTDIR"
+RMDir /r "$PROFILE\.raidionics\"
 
 !ifdef REG_START_MENU
 !insertmacro MUI_STARTMENU_GETFOLDER "Application" $SM_Folder
@@ -145,7 +145,7 @@ Delete "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk"
 Delete "$SMPROGRAMS\$SM_Folder\Uninstall ${APP_NAME}.lnk"
 Delete "$DESKTOP\${APP_NAME}.lnk"
 
-RmDir "$SMPROGRAMS\$SM_Folder"
+RMDir "$SMPROGRAMS\$SM_Folder"
 !endif
 
 DeleteRegKey ${REG_ROOT} "${REG_APP_PATH}"

--- a/assets/Raidionics.nsi
+++ b/assets/Raidionics.nsi
@@ -108,6 +108,9 @@ WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayIcon" "$INSTDIR\images\raid
 WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayVersion" "${VERSION}"
 WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "Publisher" "${COMP_NAME}"
 
+# Delete .raidionics/ directory if it exists
+RmDir /r "$PROFILE/.raidionics/"
+
 # Create directory
 CreateDirectory $INSTDIR
 

--- a/assets/Raidionics.nsi
+++ b/assets/Raidionics.nsi
@@ -130,10 +130,11 @@ SectionEnd
 
 ######################################################################
 
+# Remove location where program is installed as well as addition .raidionics/ directory in home directory
 Section Uninstall
 ${INSTALL_TYPE}
 RmDir /r "$INSTDIR"
-# RmDir /r "$PROFILE/.raidionics/resources"
+RmDir /r "$PROFILE/.raidionics/"
 
 !ifdef REG_START_MENU
 !insertmacro MUI_STARTMENU_GETFOLDER "Application" $SM_Folder


### PR DESCRIPTION
This is related to issue https://github.com/dbouget/Raidionics/issues/5.

Note that this PR only adds the fix for Windows, but I believe this is most critical there as most of the users are on Windows.

Doing the same for Linux is likely bad practice as the `.raidionics/` directory is likely created in the home directory (see [this discussion](https://unix.stackexchange.com/a/357844)).

For macOS, I'm really not sure if this makes sense, as deletion of app bundles are done in a very different way. The bundles themselves are essentially just folders which lie in `/Applications` or similar. Deleting them means to delete the folder and nothing more. There is a discussion regarding this [here](https://stackoverflow.com/a/7355959).

We should also consider creating the `.raidionics/` directory in a different directory in the future. I believe the `C:/Users/some-user/AppData/Local/` might be suitable, but not sure.